### PR TITLE
Init master branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ecw"
+version = "0.1.0"
+edition = "2021"
+authors = ["Zibtsev Vladimir <zibtsev.vladimir@gmail.com>"]
+license = "MIT"
+description = ""
+repository = "https://github.com/zvladimir/et"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+fixed = "1.28.0"
+iced = {version = "0.13.1", features = ["markdown"]}
+nom = "7.1.3"
+regex = "1.11.1"

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,0 +1,50 @@
+use iced::widget::{markdown, Scrollable};
+use iced::{Element, Theme};
+
+use crate::ohm_law;
+use crate::voltage_divider;
+
+#[derive(Debug, Clone)]
+pub struct Help {
+    markdown: Vec<markdown::Item>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    LinkClicked(()),
+}
+
+impl Help {
+    pub fn new() -> Self {
+        let help1 = ohm_law::help();
+        let help2 = voltage_divider::help();
+
+        let mut t = String::from("# Help\n");
+        t.push_str(&format!("## {}\n", &help1.0));
+        t.push_str(&help1.1);
+        t.push_str("\n\n");
+        t.push_str(&format!("## {}\n", &help2.0));
+        t.push_str(&help2.1);
+
+        Self {
+            markdown: markdown::parse(&t).collect(),
+        }
+    }
+
+    pub fn title(&self) -> String {
+        String::from("Help")
+    }
+
+    pub fn view(&self) -> Element<Message> {
+        let t = markdown::view(
+            &self.markdown,
+            markdown::Settings::default(),
+            markdown::Style::from_palette(Theme::TokyoNightStorm.palette()),
+        )
+        .map(|_v| Message::LinkClicked(()));
+
+        Scrollable::new(t).height(iced::Fill).into()
+    }
+
+    pub fn update(&mut self, _message: Message) {}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,157 @@
+#![windows_subsystem = "windows"]
+use iced::widget::{button, container::Style, row, Column, Container, Text};
+use iced::{Color, Element, Fill, Settings, Size, Theme};
+
+mod help;
+mod ohm_law;
+mod parser;
+mod types;
+mod voltage_divider;
+
+fn main() -> iced::Result {
+    iced::application(App::title, App::update, App::view)
+        .window(iced::window::Settings {
+            size: Size {
+                width: 800.0,
+                height: 600.0,
+            },
+            min_size: Some(Size {
+                width: 800.0,
+                height: 600.0,
+            }),
+            ..Default::default()
+        })
+        .settings(Settings {
+            default_font: iced::Font::DEFAULT,
+            ..Default::default()
+        })
+        .centered()
+        .run()
+}
+
+#[derive(Default)]
+struct App {
+    scene: Scene,
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    SwitchScene(SceneType),
+    OhmLawMsg(ohm_law::Message),
+    VoltageDivider(voltage_divider::Message),
+    Help(help::Message),
+}
+
+#[derive(Debug)]
+enum Scene {
+    OhmLawMsg(ohm_law::OhmLaw),
+    VoltageDivider(voltage_divider::VoltageDivider),
+    Help(help::Help),
+}
+
+#[derive(Debug, Clone)]
+enum SceneType {
+    OhmLaw,
+    VoltageDivider,
+    Help,
+}
+
+impl Default for Scene {
+    fn default() -> Self {
+        Scene::OhmLawMsg(ohm_law::OhmLaw::default())
+    }
+}
+
+impl App {
+    fn title(&self) -> String {
+        const TITLE_MAIN: &str = "Electrical Calculation Wizard";
+
+        let title_scene = match &self.scene {
+            Scene::OhmLawMsg(s) => s.title(),
+            Scene::VoltageDivider(s) => s.title(),
+            Scene::Help(s) => s.title(),
+        };
+
+        format!("{} - {}", title_scene, TITLE_MAIN)
+    }
+
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::SwitchScene(scene_type) => {
+                self.scene = match scene_type {
+                    SceneType::OhmLaw => Scene::OhmLawMsg(ohm_law::OhmLaw::default()),
+                    SceneType::VoltageDivider => {
+                        Scene::VoltageDivider(voltage_divider::VoltageDivider::default())
+                    }
+                    SceneType::Help => Scene::Help(help::Help::new()),
+                };
+            }
+            Message::VoltageDivider(msg) => {
+                if let Scene::VoltageDivider(scene) = &mut self.scene {
+                    scene.update(msg);
+                }
+            }
+            Message::OhmLawMsg(msg) => {
+                if let Scene::OhmLawMsg(scene) = &mut self.scene {
+                    scene.update(msg);
+                }
+            }
+            Message::Help(msg) => {
+                if let Scene::Help(scene) = &mut self.scene {
+                    scene.update(msg);
+                }
+            }
+        }
+    }
+
+    fn view_sidebar(&self) -> Element<Message> {
+        Column::new()
+            .push(
+                button("Ohm Law")
+                    .on_press(Message::SwitchScene(SceneType::OhmLaw))
+                    .width(Fill),
+            )
+            .push(
+                button("Voltage Divider")
+                    .on_press(Message::SwitchScene(SceneType::VoltageDivider))
+                    .width(Fill),
+            )
+            .push(Text::new("").height(Fill))
+            .push(
+                button("Help")
+                    .on_press(Message::SwitchScene(SceneType::Help))
+                    .width(Fill),
+            )
+            .spacing(5)
+            .into()
+    }
+
+    fn view_context(&self) -> Element<Message> {
+        match &self.scene {
+            Scene::OhmLawMsg(scene) => scene.view().map(Message::OhmLawMsg),
+            Scene::VoltageDivider(scene) => scene.view().map(Message::VoltageDivider),
+            Scene::Help(scene) => scene.view().map(Message::Help),
+        }
+    }
+
+    fn view(&self) -> Element<Message> {
+        let sidebar = Container::new(self.view_sidebar())
+            .padding(5)
+            .width(150)
+            .height(Fill)
+            .style(|_t: &Theme| Style {
+                background: Some(Color::from_rgb8(8, 21, 40).into()),
+                ..Style::default()
+            });
+        let content = Container::new(self.view_context())
+            .padding(10)
+            .height(Fill)
+            .width(Fill)
+            .style(|_t: &Theme| Style {
+                background: Some(Color::from_rgb8(246, 246, 246).into()),
+                ..Style::default()
+            });
+
+        row![sidebar, content].into()
+    }
+}

--- a/src/ohm_law/mod.rs
+++ b/src/ohm_law/mod.rs
@@ -1,0 +1,737 @@
+use iced::widget::{Column, Container, Row, Rule, Text, TextInput};
+use iced::{Alignment, Color, Element, Fill};
+
+use crate::types::{current::Current, power::Power, resistance::Resistance, voltage::Voltage};
+use crate::types::{Measurement, ParserError};
+
+#[derive(Debug, Clone)]
+pub struct OhmLaw {
+    fields_enable: FieldsEnable,
+    data_raw: OhmDataRaw,
+    data: OhmData,
+    calc_type: CalcType,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CalcType {
+    None, // None
+    VCRP, // Input V, C; Calc R, P
+    VRCP, // Input V, R; Calc C, P
+    VPCR, // Input V, P; Calc C, R
+    CRVP, // Input C, R; Calc V, P
+    CPVR, // Input C, P; Calc V, R
+    RPVC, // Input R, P; Calc V, C
+}
+
+impl Default for OhmLaw {
+    fn default() -> Self {
+        OhmLaw {
+            fields_enable: FieldsEnable::default(),
+            data_raw: OhmDataRaw::default(),
+            data: OhmData::default(),
+            calc_type: CalcType::None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FieldsEnable {
+    voltage: bool,
+    current: bool,
+    resistance: bool,
+    power: bool,
+}
+
+impl Default for FieldsEnable {
+    fn default() -> Self {
+        Self {
+            voltage: true,
+            current: true,
+            resistance: true,
+            power: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct OhmData {
+    voltage: Result<Voltage, ParserError>,
+    current: Result<Current, ParserError>,
+    resistance: Result<Resistance, ParserError>,
+    power: Result<Power, ParserError>,
+}
+
+impl Default for OhmData {
+    fn default() -> Self {
+        Self {
+            voltage: Err(ParserError::EmptyInput),
+            current: Err(ParserError::EmptyInput),
+            resistance: Err(ParserError::EmptyInput),
+            power: Err(ParserError::EmptyInput),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct OhmDataRaw {
+    voltage: String,
+    current: String,
+    resistance: String,
+    power: String,
+}
+
+impl Default for OhmDataRaw {
+    fn default() -> Self {
+        Self {
+            voltage: String::new(),
+            current: String::new(),
+            resistance: String::new(),
+            power: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    InputVoltageChanged(String),
+    InputCurrentChanged(String),
+    InputResistanceChanged(String),
+    InputPowerChanged(String),
+}
+
+impl OhmLaw {
+    pub fn title(&self) -> String {
+        String::from("Ohm Law")
+    }
+
+    pub fn update(&mut self, message: Message) {
+        match message {
+            Message::InputVoltageChanged(s) => {
+                self.data_raw.voltage = s;
+                self.data.voltage = self.data_raw.voltage.parse::<Voltage>();
+            }
+            Message::InputCurrentChanged(s) => {
+                self.data_raw.current = s;
+                self.data.current = self.data_raw.current.parse::<Current>();
+            }
+            Message::InputResistanceChanged(s) => {
+                self.data_raw.resistance = s;
+                self.data.resistance = self.data_raw.resistance.parse::<Resistance>();
+            }
+            Message::InputPowerChanged(s) => {
+                self.data_raw.power = s;
+                self.data.power = self.data_raw.power.parse::<Power>();
+            }
+        }
+
+        self.determine_calctype();
+        self.update_field_accessibility();
+        self.calculating();
+    }
+
+    fn determine_calctype(&mut self) {
+        let voltage_filled = !self.data_raw.voltage.trim().is_empty() && self.data.voltage.is_ok();
+        let current_filled = !self.data_raw.current.trim().is_empty() && self.data.current.is_ok();
+        let resistance_filled =
+            !self.data_raw.resistance.trim().is_empty() && self.data.resistance.is_ok();
+        let power_filled = !self.data_raw.power.trim().is_empty() && self.data.power.is_ok();
+
+        match (
+            voltage_filled,
+            current_filled,
+            resistance_filled,
+            power_filled,
+        ) {
+            (true, true, _, _) => self.calc_type = CalcType::VCRP,
+            (true, _, true, _) => self.calc_type = CalcType::VRCP,
+            (true, _, _, true) => self.calc_type = CalcType::VPCR,
+            (_, true, true, _) => self.calc_type = CalcType::CRVP,
+            (_, true, _, true) => self.calc_type = CalcType::CPVR,
+            (_, _, true, true) => self.calc_type = CalcType::RPVC,
+            _ => self.calc_type = CalcType::None,
+        }
+    }
+
+    fn update_field_accessibility(&mut self) {
+        match self.calc_type {
+            CalcType::VCRP => {
+                self.fields_enable.resistance = false;
+                self.fields_enable.power = false;
+
+                self.data_raw.resistance.clear();
+                self.data_raw.power.clear();
+            }
+            CalcType::VRCP => {
+                self.fields_enable.current = false;
+                self.fields_enable.power = false;
+
+                self.data_raw.current.clear();
+                self.data_raw.power.clear();
+            }
+            CalcType::VPCR => {
+                self.fields_enable.current = false;
+                self.fields_enable.resistance = false;
+
+                self.data_raw.current.clear();
+                self.data_raw.resistance.clear();
+            }
+            CalcType::CRVP => {
+                self.fields_enable.voltage = false;
+                self.fields_enable.power = false;
+
+                self.data_raw.voltage.clear();
+                self.data_raw.power.clear();
+            }
+            CalcType::CPVR => {
+                self.fields_enable.voltage = false;
+                self.fields_enable.resistance = false;
+
+                self.data_raw.resistance.clear();
+                self.data_raw.voltage.clear();
+            }
+            CalcType::RPVC => {
+                self.fields_enable.voltage = false;
+                self.fields_enable.current = false;
+
+                self.data_raw.voltage.clear();
+                self.data_raw.current.clear();
+            }
+            CalcType::None => self.fields_enable = FieldsEnable::default(),
+        }
+    }
+
+    fn calculating(&mut self) {
+        match self.calc_type {
+            CalcType::VCRP => {
+                if let (Ok(voltage), Ok(current)) =
+                    (self.data.voltage.clone(), self.data.current.clone())
+                {
+                    self.data.resistance = Ok(voltage / current);
+                    self.data.power = Ok(voltage * current);
+                }
+            }
+            CalcType::VRCP => {
+                if let (Ok(voltage), Ok(resistance)) =
+                    (self.data.voltage.clone(), self.data.resistance.clone())
+                {
+                    let current = voltage / resistance;
+
+                    self.data.current = Ok(current);
+                    self.data.power = Ok(voltage * current);
+                }
+            }
+            CalcType::VPCR => {
+                if let (Ok(voltage), Ok(power)) =
+                    (self.data.voltage.clone(), self.data.power.clone())
+                {
+                    let current = power / voltage;
+
+                    self.data.current = Ok(current);
+                    self.data.resistance = Ok(voltage / current);
+                }
+            }
+            CalcType::CRVP => {
+                if let (Ok(resistance), Ok(current)) =
+                    (self.data.resistance.clone(), self.data.current.clone())
+                {
+                    let voltage = current * resistance;
+
+                    self.data.voltage = Ok(voltage);
+                    self.data.power = Ok(voltage * current);
+                }
+            }
+            CalcType::CPVR => {
+                if let (Ok(power), Ok(current)) =
+                    (self.data.power.clone(), self.data.current.clone())
+                {
+                    let voltage = power * current;
+
+                    self.data.voltage = Ok(voltage);
+                    self.data.resistance = Ok(voltage / current);
+                }
+            }
+            CalcType::RPVC => {
+                if let (Ok(power), Ok(resistance)) =
+                    (self.data.power.clone(), self.data.resistance.clone())
+                {
+                    let voltage = Voltage {
+                        value: (power.value * resistance.value).sqrt(),
+                        tolerance: None,
+                    };
+                    let current = Current {
+                        value: (power.value / resistance.value).sqrt(),
+                        tolerance: None,
+                    };
+
+                    self.data.voltage = Ok(voltage);
+                    self.data.current = Ok(current);
+                }
+            }
+            CalcType::None => (),
+        }
+    }
+
+    pub fn view(&self) -> Element<Message> {
+        Column::new()
+            .push(self.view_form())
+            .push(self.view_result())
+            .into()
+    }
+
+    fn view_result(&self) -> Element<Message> {
+        fn format_measurement<T: Measurement, E>(data: Result<T, E>) -> (String, String, String) {
+            match data {
+                Ok(measurement) => (
+                    measurement.get_value_nom(),
+                    measurement.get_value_min(),
+                    measurement.get_value_max(),
+                ),
+                Err(_) => ("N/A".to_string(), "N/A".to_string(), "N/A".to_string()),
+            }
+        }
+        fn format_tol<T: Measurement, E>(data: Result<T, E>) -> (String, String, String, String) {
+            match data {
+                Ok(measurement) => (
+                    measurement.get_tol_value_plus(),
+                    measurement.get_tol_value_minus(),
+                    measurement.get_tol_percent_plus(),
+                    measurement.get_tol_percent_minus(),
+                ),
+                Err(_) => (
+                    "N/A".to_string(),
+                    "N/A".to_string(),
+                    "N/A".to_string(),
+                    "N/A".to_string(),
+                ),
+            }
+        }
+
+        let (voltage_nom, voltage_min, voltage_max) = format_measurement(self.data.voltage.clone());
+        let (voltage_tol_plus, voltage_tol_minus, voltage_tol_plus_p, voltage_tol_minus_p) =
+            format_tol(self.data.voltage.clone());
+
+        let (current_nom, current_min, current_max) = format_measurement(self.data.current.clone());
+        let (current_tol_plus, current_tol_minus, current_tol_plus_p, current_tol_minus_p) =
+            format_tol(self.data.current.clone());
+
+        let (resistance_nom, resistance_min, resistance_max) =
+            format_measurement(self.data.resistance.clone());
+        let (
+            resistance_tol_plus,
+            resistance_tol_minus,
+            resistance_tol_plus_p,
+            resistance_tol_minus_p,
+        ) = format_tol(self.data.resistance.clone());
+
+        let (power_nom, power_min, power_max) = format_measurement(self.data.power.clone());
+        let (power_tol_plus, power_tol_minus, power_tol_plus_p, power_tol_minus_p) =
+            format_tol(self.data.power.clone());
+
+        let data = vec![
+            vec![
+                "Value nom".to_string(),
+                voltage_nom,
+                current_nom,
+                resistance_nom,
+                power_nom,
+            ],
+            vec![
+                "Value max".to_string(),
+                voltage_max,
+                current_max,
+                resistance_max,
+                power_max,
+            ],
+            vec![
+                "Value min".to_string(),
+                voltage_min,
+                current_min,
+                resistance_min,
+                power_min,
+            ],
+            vec![
+                "Tol plus".to_string(),
+                voltage_tol_plus,
+                current_tol_plus,
+                resistance_tol_plus,
+                power_tol_plus,
+            ],
+            vec![
+                "Tol minus".to_string(),
+                voltage_tol_minus,
+                current_tol_minus,
+                resistance_tol_minus,
+                power_tol_minus,
+            ],
+            vec![
+                "Tol plus, %".to_string(),
+                voltage_tol_plus_p,
+                current_tol_plus_p,
+                resistance_tol_plus_p,
+                power_tol_plus_p,
+            ],
+            vec![
+                "Tol minus, %".to_string(),
+                voltage_tol_minus_p,
+                current_tol_minus_p,
+                resistance_tol_minus_p,
+                power_tol_minus_p,
+            ],
+        ];
+        let result = self.view_table(data);
+
+        Container::new(result).padding([1, 0]).into()
+    }
+
+    fn view_table(&self, data: Vec<Vec<String>>) -> Element<Message> {
+        const RULE_WIDTH: u16 = 0;
+        const COLUMN_FIRST_WIDTH: u16 = 110;
+
+        fn text_output(s: String) -> Element<'static, Message> {
+            let t = Text::new(s).width(Fill);
+
+            Container::new(t).padding(5).into()
+        }
+
+        fn row_line(
+            column1: String,
+            column2: String,
+            column3: String,
+            column4: String,
+            column5: String,
+        ) -> Element<'static, Message> {
+            Row::new()
+                .push(Rule::vertical(RULE_WIDTH))
+                .push(Container::new(text_output(column1)).width(COLUMN_FIRST_WIDTH))
+                .push(Rule::vertical(RULE_WIDTH))
+                .push(Text::new("").width(1)) // double rule line
+                .push(Rule::vertical(RULE_WIDTH))
+                .push(text_output(column2))
+                .push(Rule::vertical(RULE_WIDTH))
+                .push(text_output(column3))
+                .push(Rule::vertical(RULE_WIDTH))
+                .push(text_output(column4))
+                .push(Rule::vertical(RULE_WIDTH))
+                .push(text_output(column5))
+                .push(Rule::vertical(RULE_WIDTH))
+                .height(30)
+                .width(Fill)
+                .into()
+        }
+
+        let mut elements = Vec::new();
+        // header
+        let r = row_line(
+            "".to_string(),
+            "Voltage".to_string(),
+            "Current".to_string(),
+            "Resistance".to_string(),
+            "Power".to_string(),
+        );
+        elements.push(Rule::horizontal(RULE_WIDTH).into());
+        elements.push(r);
+        elements.push(Rule::horizontal(RULE_WIDTH).into());
+        elements.push(Text::new("").height(1).into());
+        elements.push(Rule::horizontal(RULE_WIDTH).into());
+
+        // data
+        for d in data {
+            let r = row_line(
+                d[0].clone(),
+                d[1].clone(),
+                d[2].clone(),
+                d[3].clone(),
+                d[4].clone(),
+            );
+            elements.push(r);
+            elements.push(Rule::horizontal(RULE_WIDTH).into());
+        }
+
+        Column::from_vec(elements)
+            .padding([5, 0])
+            .width(Fill)
+            .into()
+    }
+
+    fn view_form(&self) -> Element<Message> {
+        let under_text = match &self.data.voltage {
+            Err(ParserError::IncorrectInput(e)) => e,
+            _ => "Example: 10.5 +3% -7.6%",
+        };
+        let voltage_field = self.create_input_field(
+            "Voltage",
+            &self.data_raw.voltage,
+            |s| Message::InputVoltageChanged(s),
+            under_text,
+            self.fields_enable.voltage,
+        );
+        let under_text = match &self.data.voltage {
+            Err(ParserError::IncorrectInput(e)) => e,
+            _ => "Example: 100m +1% -1%",
+        };
+        let current_field = self.create_input_field(
+            "Current",
+            &self.data_raw.current,
+            |s| Message::InputCurrentChanged(s),
+            under_text,
+            self.fields_enable.current,
+        );
+        let under_text = match &self.data.resistance {
+            Err(ParserError::IncorrectInput(e)) => e,
+            _ => "Example: 10k 5%",
+        };
+        let resistance_field = self.create_input_field(
+            "Resistance",
+            &self.data_raw.resistance,
+            |s| Message::InputResistanceChanged(s),
+            under_text,
+            self.fields_enable.resistance,
+        );
+        let under_text = match &self.data.power {
+            Err(ParserError::IncorrectInput(e)) => e,
+            _ => "Example: 1k 5%",
+        };
+        let power_field = self.create_input_field(
+            "Power",
+            &self.data_raw.power,
+            |s| Message::InputPowerChanged(s),
+            under_text,
+            self.fields_enable.power,
+        );
+
+        Column::new()
+            .push(voltage_field)
+            .push(current_field)
+            .push(resistance_field)
+            .push(power_field)
+            .into()
+    }
+
+    fn create_input_field<'a>(
+        &self,
+        label_text: &'a str,
+        input_value: &'a str,
+        on_input: impl Fn(String) -> Message + 'a,
+        under_text: &'a str,
+        enable: bool,
+    ) -> Element<'a, Message> {
+        // Константы для стилей
+        const LABEL_WIDTH: u16 = 110;
+        const FIELD_HEIGHT: u16 = 30;
+        const LABEL_SIZE: u16 = 15;
+        const INPUT_SIZE: u16 = 15;
+        const UNDER_TEXT_SIZE: u16 = 12;
+        const PADDING_ROW: [u16; 2] = [0, 0];
+        const PADDING_COLUMN: [u16; 2] = [5, 0];
+        const UNDER_TEXT_PADDING: [u16; 2] = [0, LABEL_WIDTH];
+
+        // Метка
+        let label = Text::new(label_text).size(LABEL_SIZE);
+        let label = Container::new(label)
+            .align_y(Alignment::Center)
+            .width(LABEL_WIDTH)
+            .height(FIELD_HEIGHT)
+            .padding(PADDING_ROW);
+
+        // Поле ввода
+        let mut input = TextInput::new("", input_value).size(INPUT_SIZE);
+        if enable == true {
+            input = input.on_input(on_input);
+        }
+        let input = Container::new(input)
+            .align_y(Alignment::Center)
+            .width(Fill)
+            .height(FIELD_HEIGHT);
+
+        // Подсказка
+        let under_text = Text::new(under_text)
+            .size(UNDER_TEXT_SIZE)
+            .color(Color::from_rgb8(128, 128, 128));
+        let under_text = Container::new(under_text)
+            .align_y(Alignment::Center)
+            .padding(UNDER_TEXT_PADDING);
+
+        // Компоновка
+        Column::new()
+            .push(Row::new().push(label).push(input))
+            .push(under_text)
+            .padding(PADDING_COLUMN)
+            .into()
+    }
+}
+
+pub fn help() -> (String, String) {
+    let title = String::from("Ohm Law\n");
+    let text = String::from("
+The program performs calculations based on Ohm's Law: **U = I × R** and the power formula: **P = U × I**, where:  
+- **U** — Voltage (volts, V),  
+- **I** — Current (amperes, A),  
+- **R** — Resistance (ohms, Ω),  
+- **P** — Power (watts, W).
+
+#### How to Use
+1. Fill in any **two known fields** out of the four: voltage (**U**), current (**I**), resistance (**R**), or power (**P**).
+2. After filling in two fields, the remaining fields will become read-only.
+3. The results will be displayed in the table below.
+
+If a parameter cannot be calculated, it will be marked as **N/A**.
+
+#### Data Input Format
+##### Value Units
+Each input field supports values with units. To specify a unit, append the unit prefix directly to the number:  
+- Example: 12m represents 0.012V (millivolts).  
+
+Supported unit prefixes:  
+- **p** (pico, 10⁻¹²),  
+- **n** (nano, 10⁻⁹),  
+- **u** (micro, 10⁻⁶),  
+- **m** (milli, 10⁻³),  
+- **k** (kilo, 10³),  
+- **M** (mega, 10⁶),  
+- **G** (giga, 10⁹).
+
+##### Uncertainty (Error Margins)
+Input values can include error margins using the following formats:  
+- Symmetrical error: 5% (±5% from the value),  
+- Asymmetrical positive error: +5%,  
+- Asymmetrical negative error: -5%,  
+- Symmetrical error: +/-5%.
+
+#### Error Handling in Results
+All input uncertainties are considered during calculations. The results will reflect the range of uncertainty based on the provided error margins.
+");
+
+    (title, text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculating_vcrp() {
+        let mut ohm_law = OhmLaw::default();
+        ohm_law.data.voltage = Ok(Voltage {
+            value: 10.0,
+            tolerance: None,
+        });
+        ohm_law.data.current = Ok(Current {
+            value: 2.0,
+            tolerance: None,
+        });
+        ohm_law.calc_type = CalcType::VCRP;
+
+        ohm_law.calculating();
+
+        assert_eq!(ohm_law.data.resistance.unwrap().get_nominal_value(), 5.0); // R = V / I
+        assert_eq!(ohm_law.data.power.unwrap().get_nominal_value(), 20.0); // P = V * I
+    }
+
+    #[test]
+    fn test_calculating_vrcp() {
+        let mut ohm_law = OhmLaw::default();
+        ohm_law.data.voltage = Ok(Voltage {
+            value: 12.0,
+            tolerance: None,
+        });
+        ohm_law.data.resistance = Ok(Resistance {
+            value: 4.0,
+            tolerance: None,
+        });
+        ohm_law.calc_type = CalcType::VRCP;
+
+        ohm_law.calculating();
+
+        assert_eq!(ohm_law.data.current.unwrap().get_nominal_value(), 3.0); // I = V / R
+        assert_eq!(ohm_law.data.power.unwrap().get_nominal_value(), 36.0); // P = V * I
+    }
+
+    #[test]
+    fn test_calculating_vpcr() {
+        let mut ohm_law = OhmLaw::default();
+        ohm_law.data.voltage = Ok(Voltage {
+            value: 15.0,
+            tolerance: None,
+        });
+        ohm_law.data.power = Ok(Power {
+            value: 30.0,
+            tolerance: None,
+        });
+        ohm_law.calc_type = CalcType::VPCR;
+
+        ohm_law.calculating();
+
+        assert_eq!(ohm_law.data.current.unwrap().get_nominal_value(), 2.0); // I = P / V
+        assert_eq!(ohm_law.data.resistance.unwrap().get_nominal_value(), 7.5); // R = V / I
+    }
+
+    #[test]
+    fn test_calculating_crvp() {
+        let mut ohm_law = OhmLaw::default();
+        ohm_law.data.current = Ok(Current {
+            value: 2.0,
+            tolerance: None,
+        });
+        ohm_law.data.resistance = Ok(Resistance {
+            value: 5.0,
+            tolerance: None,
+        });
+        ohm_law.calc_type = CalcType::CRVP;
+
+        ohm_law.calculating();
+
+        assert_eq!(ohm_law.data.voltage.unwrap().get_nominal_value(), 10.0); // V = I * R
+        assert_eq!(ohm_law.data.power.unwrap().get_nominal_value(), 20.0); // P = V * I
+    }
+
+    #[test]
+    fn test_calculating_cpvr() {
+        let mut ohm_law = OhmLaw::default();
+        ohm_law.data.current = Ok(Current {
+            value: 3.0,
+            tolerance: None,
+        });
+        ohm_law.data.power = Ok(Power {
+            value: 27.0,
+            tolerance: None,
+        });
+        ohm_law.calc_type = CalcType::CPVR;
+
+        ohm_law.calculating();
+
+        assert_eq!(ohm_law.data.voltage.unwrap().get_nominal_value(), 9.0); // V = P / I
+        assert_eq!(ohm_law.data.resistance.unwrap().get_nominal_value(), 3.0); // R = V / I
+    }
+
+    #[test]
+    fn test_calculating_rpvc() {
+        let mut ohm_law = OhmLaw::default();
+        ohm_law.data.resistance = Ok(Resistance {
+            value: 4.0,
+            tolerance: None,
+        });
+        ohm_law.data.power = Ok(Power {
+            value: 64.0,
+            tolerance: None,
+        });
+        ohm_law.calc_type = CalcType::RPVC;
+
+        ohm_law.calculating();
+
+        assert_eq!(ohm_law.data.voltage.unwrap().get_nominal_value(), 16.0); // V = sqrt(P * R)
+        assert_eq!(ohm_law.data.current.unwrap().get_nominal_value(), 4.0); // I = sqrt(P / R)
+    }
+
+    #[test]
+    fn test_calculating_none() {
+        let mut ohm_law = OhmLaw::default();
+        ohm_law.calc_type = CalcType::None;
+
+        ohm_law.calculating();
+
+        assert!(ohm_law.data.voltage.is_err());
+        assert!(ohm_law.data.current.is_err());
+        assert!(ohm_law.data.resistance.is_err());
+        assert!(ohm_law.data.power.is_err());
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,262 @@
+//! # Parsers for Floating-Point Numbers and Their Formats
+//!
+//! This library provides parsers for string data that contains:
+//! - floating-point numbers (`double`)
+//! - numbers with prefixes and suffixes (`%`, `+/-`, `m`, `k`, etc.`)
+//! - tolerance values (`-5%`, `+5%`, `+/-5%`)
+//!
+//! For example:
+//! - `"5%"` is parsed as `TolPlusMinus(5.0)`
+//! - `"+5%"` is parsed as `TolPlus(5.0)`
+//! - `"-5%"` is parsed as `TolMinus(5.0)`
+//! - `"10m"` is parsed as `NumberSuffix(10.0, Dim::Milli)`
+
+use crate::types::Dim;
+use nom::{
+    branch::alt,
+    bytes::complete::tag,
+    character::complete::{char, space1},
+    multi::separated_list1,
+    number::complete::double,
+    IResult,
+};
+
+/// Enum for various data types that can be parsed.
+#[derive(Debug, PartialEq)]
+pub enum Block {
+    /// A number with a negative sign (e.g., "-5%")
+    TolMinus(f64),
+    /// A number with a positive sign (e.g., "+5%")
+    TolPlus(f64),
+    /// A simple number (e.g., "5%") treated as both positive and negative tolerance
+    TolPlusMinus(f64),
+    /// A simple number (e.g., "5.0")
+    Number(f64),
+    /// A number with a suffix (e.g., "5k", "10m")
+    NumberSuffix((f64, Dim)),
+}
+
+/// Parser for a string in the format "-float%"
+///
+/// # Example
+///
+/// ```rust
+/// use your_crate::percentage_minus_parser;
+/// assert_eq!(percentage_minus_parser("-5%"), Ok(("", Block::TolMinus(5.0))));
+/// ```
+fn percentage_minus_parser(input: &str) -> IResult<&str, Block> {
+    let (input, _) = tag("-")(input)?;
+    let (input, number) = double(input)?;
+    let (input, _) = tag("%")(input)?;
+
+    Ok((input, Block::TolMinus(number.abs())))
+}
+
+/// Parser for a string in the format "+/-float%"
+///
+/// # Example
+///
+/// ```rust
+/// use your_crate::percentage_plus_minus_parser;
+/// assert_eq!(percentage_plus_minus_parser("+/-5%"), Ok(("", Block::TolPlusMinus(5.0))));
+/// ```
+fn percentage_plus_minus_parser(input: &str) -> IResult<&str, Block> {
+    let (input, _) = tag("+/-")(input)?;
+    let (input, number) = double(input)?;
+    let (input, _) = tag("%")(input)?;
+
+    Ok((input, Block::TolPlusMinus(number)))
+}
+
+/// Parser for a string in the format "float%" (e.g., "5%").
+/// Returns a block with `TolPlusMinus` where the value is both the positive and negative tolerance.
+///
+/// # Example
+///
+/// ```rust
+/// use your_crate::percentage_plus_parser2;
+/// assert_eq!(percentage_plus_parser2("5%"), Ok(("", Block::TolPlusMinus(5.0))));
+/// ```
+fn percentage_plus_minus_parser2(input: &str) -> IResult<&str, Block> {
+    let (input, number) = double(input)?;
+    let (input, _) = tag("%")(input)?;
+
+    Ok((input, Block::TolPlusMinus(number)))
+}
+
+/// Parser for a string in the format "+float%"
+///
+/// # Example
+///
+/// ```rust
+/// use your_crate::percentage_plus_parser;
+/// assert_eq!(percentage_plus_parser("+5%"), Ok(("", Block::TolPlus(5.0))));
+/// ```
+fn percentage_plus_parser(input: &str) -> IResult<&str, Block> {
+    let (input, _) = tag("+")(input)?;
+    let (input, number) = double(input)?;
+    let (input, _) = tag("%")(input)?;
+
+    Ok((input, Block::TolPlus(number)))
+}
+
+/// Parser for a simple floating-point number (e.g., "5.67")
+///
+/// # Example
+///
+/// ```rust
+/// use your_crate::double_parser;
+/// assert_eq!(double_parser("5.67"), Ok(("", Block::Number(5.67))));
+/// ```
+fn double_parser(input: &str) -> IResult<&str, Block> {
+    let (input, number) = double(input)?;
+    Ok((input, Block::Number(number)))
+}
+
+/// Parser for a floating-point number followed by a suffix ('m', 'k', 'M', 'p')
+///
+/// # Example
+///
+/// ```rust
+/// use your_crate::double_suffix_parser;
+/// assert_eq!(double_suffix_parser("5k"), Ok(("", Block::NumberSuffix((5.0, Dim::Kilo)))));
+/// ```
+fn double_suffix_parser(input: &str) -> IResult<&str, Block> {
+    let (input, number) = double(input)?;
+
+    let (input, suffix) = alt((
+        char('p'), // p -> Pico
+        char('n'), // n -> Nano
+        char('u'), // u -> Micro
+        char('m'), // m -> Milli
+        char('k'), // k -> Kilo
+        char('M'), // M -> Mega
+        char('G'), // G -> Giga
+        char('T'), // T -> Tera
+    ))(input)?;
+
+    let suffix: Dim = suffix.into();
+    let result = Block::NumberSuffix((number, suffix));
+
+    Ok((input, result))
+}
+
+/// Parser that tries multiple parsers in sequence
+///
+/// # Example
+///
+/// ```rust
+/// use your_crate::try_parsers;
+/// assert_eq!(try_parsers("5%"), Ok(("", Block::TolPlusMinus(5.0))));
+/// ```
+fn try_parsers(input: &str) -> IResult<&str, Block> {
+    alt((
+        percentage_plus_parser,
+        percentage_minus_parser,
+        percentage_plus_minus_parser,
+        percentage_plus_minus_parser2,
+        double_suffix_parser,
+        double_parser,
+    ))(input)
+}
+
+/// Parser that splits a string into blocks and applies parsers to each block
+///
+/// # Example
+///
+/// ```rust
+/// use your_crate::parse_blocks;
+/// assert_eq!(
+///     parse_blocks("5% 77m"),
+///     Ok(("", vec![Block::TolPlusMinus(5.0), Block::NumberSuffix((77.0, Dim::Milli))]))
+/// );
+/// ```
+pub fn parse_blocks(input: &str) -> IResult<&str, Vec<Block>> {
+    separated_list1(space1, try_parsers)(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_percentage_minus_parser() {
+        assert_eq!(
+            percentage_minus_parser("-5%"),
+            Ok(("", Block::TolMinus(5.0)))
+        );
+    }
+
+    #[test]
+    fn test_percentage_plus_minus_parser() {
+        assert_eq!(
+            percentage_plus_minus_parser("+/-5%"),
+            Ok(("", Block::TolPlusMinus(5.0)))
+        );
+    }
+
+    #[test]
+    fn test_percentage_plus_parser() {
+        assert_eq!(percentage_plus_parser("+5%"), Ok(("", Block::TolPlus(5.0))));
+    }
+
+    #[test]
+    fn test_percentage_plus_minus_parser2() {
+        assert_eq!(
+            percentage_plus_minus_parser2("5%"),
+            Ok(("", Block::TolPlusMinus(5.0)))
+        );
+        assert!(percentage_plus_minus_parser2("5").is_err());
+    }
+
+    #[test]
+    fn test_double_parser() {
+        assert_eq!(double_parser("5.67"), Ok(("", Block::Number(5.67))));
+    }
+
+    #[test]
+    fn test_double_suffix_parser() {
+        assert_eq!(
+            double_suffix_parser("5k"),
+            Ok(("", Block::NumberSuffix((5.0, Dim::Kilo))))
+        );
+        assert_eq!(
+            double_suffix_parser("10m"),
+            Ok(("", Block::NumberSuffix((10.0, Dim::Milli))))
+        );
+    }
+
+    #[test]
+    fn test_parse_blocks() {
+        let input = "5% 77m";
+        let result = parse_blocks(input);
+        assert_eq!(
+            result,
+            Ok((
+                "",
+                vec![
+                    Block::TolPlusMinus(5.0),
+                    Block::NumberSuffix((77.0, Dim::Milli))
+                ]
+            ))
+        );
+    }
+
+    #[test]
+    fn test_combined_blocks() {
+        let input = "10m +5% -5% +/-5%";
+        let result = parse_blocks(input);
+        assert_eq!(
+            result,
+            Ok((
+                "",
+                vec![
+                    Block::NumberSuffix((10.0, Dim::Milli)),
+                    Block::TolPlus(5.0),
+                    Block::TolMinus(5.0),
+                    Block::TolPlusMinus(5.0),
+                ]
+            ))
+        );
+    }
+}

--- a/src/types/current.rs
+++ b/src/types/current.rs
@@ -1,0 +1,114 @@
+use crate::types::{
+    calculate_multiplication_with_tolerance, resistance::Resistance, voltage::Voltage, Measurement,
+    ParserError, Tolerance,
+};
+use crate::{parser, parser::Block};
+use std::{ops::Mul, str::FromStr};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Current {
+    pub value: f64,
+    pub tolerance: Option<Tolerance>,
+}
+
+impl Default for Current {
+    fn default() -> Self {
+        Self {
+            value: 0.0,
+            tolerance: None,
+        }
+    }
+}
+
+impl Measurement for Current {
+    fn get_nominal_value(&self) -> f64 {
+        self.value
+    }
+
+    fn get_tolerance(&self) -> Option<Tolerance> {
+        self.tolerance
+    }
+
+    fn get_unit(&self) -> &'static str {
+        "A"
+    }
+}
+
+impl FromStr for Current {
+    type Err = ParserError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let input = input.trim();
+        if input.trim().is_empty() {
+            return Err(ParserError::EmptyInput);
+        }
+
+        match parser::parse_blocks(input) {
+            Ok((input, result)) => {
+                // If there is any remaining unparsed input, it's an error
+                if !input.is_empty() {
+                    return Err(ParserError::IncorrectInput(input.to_string()));
+                }
+
+                let mut value = f64::NAN;
+                let mut tol: Option<Tolerance> = None;
+
+                // Process each parsed block
+                for block in result {
+                    match block {
+                        Block::Number(n) => value = n,
+                        Block::NumberSuffix((n, s)) => value = n * s.coefficient(),
+                        Block::TolMinus(t) => {
+                            tol = if let Some(tt) = tol {
+                                Some(Tolerance {
+                                    plus: tt.plus,
+                                    minus: t,
+                                })
+                            } else {
+                                Some(Tolerance {
+                                    plus: 0.0,
+                                    minus: t,
+                                })
+                            };
+                        }
+                        Block::TolPlus(t) => {
+                            tol = if let Some(tt) = tol {
+                                Some(Tolerance {
+                                    plus: t,
+                                    minus: tt.minus,
+                                })
+                            } else {
+                                Some(Tolerance {
+                                    plus: t,
+                                    minus: 0.0,
+                                })
+                            };
+                        }
+                        Block::TolPlusMinus(t) => {
+                            tol = Some(Tolerance { plus: t, minus: t });
+                        }
+                    }
+                }
+
+                Ok(Current {
+                    value,
+                    tolerance: tol,
+                })
+            }
+            Err(e) => Err(ParserError::IncorrectInput(e.to_string())),
+        }
+    }
+}
+
+impl Mul<Resistance> for Current {
+    type Output = Voltage;
+
+    fn mul(self, rhs: Resistance) -> Self::Output {
+        let (value, tol) = calculate_multiplication_with_tolerance(&self, &rhs);
+
+        Voltage {
+            value: value,
+            tolerance: tol,
+        }
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,505 @@
+pub mod current;
+pub mod power;
+pub mod resistance;
+pub mod voltage;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParserError {
+    EmptyInput,
+    IncorrectInput(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Tolerance {
+    pub plus: f64,
+    pub minus: f64,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Dim {
+    Pico,
+    Nano,
+    Micro,
+    Milli,
+    None,
+    Kilo,
+    Mega,
+    Giga,
+    Tera,
+}
+
+impl From<char> for Dim {
+    fn from(c: char) -> Self {
+        match c {
+            'p' => Dim::Pico,
+            'n' => Dim::Nano,
+            'u' => Dim::Micro,
+            'm' => Dim::Milli,
+            'k' => Dim::Kilo,
+            'M' => Dim::Mega,
+            'G' => Dim::Giga,
+            'T' => Dim::Tera,
+            _ => Dim::None,
+        }
+    }
+}
+
+impl Dim {
+    /// Converts the `Dim` variant to its corresponding coefficient (as a power of 10).
+    pub fn coefficient(&self) -> f64 {
+        match self {
+            Dim::Pico => 1e-12,
+            Dim::Nano => 1e-9,
+            Dim::Micro => 1e-6,
+            Dim::Milli => 1e-3,
+            Dim::None => 1.0, // No scaling factor
+            Dim::Kilo => 1e3,
+            Dim::Mega => 1e6,
+            Dim::Giga => 1e9,
+            Dim::Tera => 1e12,
+        }
+    }
+}
+
+pub trait Measurement {
+    fn get_nominal_value(&self) -> f64;
+    fn get_tolerance(&self) -> Option<Tolerance>;
+    fn get_unit(&self) -> &'static str;
+
+    fn normalize(&self, value: f64) -> String {
+        let unit = self.get_unit();
+        let prefixes = [
+            (1e-12, "p"),
+            (1e-9, "n"),
+            (1e-6, "u"),
+            (1e-3, "m"),
+            (1.0, ""),
+            (1e3, "k"),
+            (1e6, "M"),
+            (1e9, "G"),
+            (1e12, "T"),
+        ];
+
+        for &(threshold, prefix) in prefixes.iter().rev() {
+            if value.abs() >= threshold {
+                let formatted_value = value / threshold;
+                return format!("{:.2}{}{}", formatted_value, prefix, unit);
+            }
+        }
+
+        format!("{}", value)
+    }
+
+    fn get_value_nom(&self) -> String {
+        let value = self.get_nominal_value();
+
+        self.normalize(value)
+    }
+
+    fn get_value_min(&self) -> String {
+        if let Some(tol) = self.get_tolerance() {
+            let min = self.get_nominal_value() * (100.0 - tol.minus) / 100.0;
+            self.normalize(min)
+        } else {
+            "N/A".to_string()
+        }
+    }
+
+    fn get_value_max(&self) -> String {
+        if let Some(tol) = self.get_tolerance() {
+            let max = self.get_nominal_value() * (100.0 + tol.plus) / 100.0;
+            self.normalize(max)
+        } else {
+            "N/A".to_string()
+        }
+    }
+
+    fn get_tol_value_plus(&self) -> String {
+        if let Some(tol) = self.get_tolerance() {
+            let delta = self.get_nominal_value() * tol.plus / 100.0;
+            self.normalize(delta)
+        } else {
+            "N/A".to_string()
+        }
+    }
+
+    fn get_tol_value_minus(&self) -> String {
+        if let Some(tol) = self.get_tolerance() {
+            let delta = self.get_nominal_value() * tol.minus / 100.0;
+            let result = self.normalize(delta);
+            format!("-{}", result)
+        } else {
+            "N/A".to_string()
+        }
+    }
+
+    fn get_tol_percent_plus(&self) -> String {
+        if let Some(tol) = self.get_tolerance() {
+            format!("{:.2}%", tol.plus)
+        } else {
+            "N/A".to_string()
+        }
+    }
+
+    fn get_tol_percent_minus(&self) -> String {
+        if let Some(tol) = self.get_tolerance() {
+            format!("-{:.2}%", tol.minus)
+        } else {
+            "N/A".to_string()
+        }
+    }
+}
+
+pub fn calculate_multiplication_with_tolerance<M: Measurement, N: Measurement>(
+    factor1: &M,
+    factor2: &N,
+) -> (f64, Option<Tolerance>) {
+    let operand1_nom = factor1.get_nominal_value();
+    let operand2_nom = factor2.get_nominal_value();
+
+    let result = operand1_nom * operand2_nom;
+
+    let operand1_tol = factor1.get_tolerance();
+    let operand2_tol = factor2.get_tolerance();
+
+    if operand1_tol.is_none() && operand2_tol.is_none() {
+        return (result, None);
+    }
+
+    let (operand1_min, operand1_max) = match operand1_tol {
+        Some(tol) => (tol.minus, tol.plus),
+        None => (0.0, 0.0),
+    };
+
+    let (operand2_min, operand2_max) = match operand2_tol {
+        Some(tol) => (tol.minus, tol.plus),
+        None => (0.0, 0.0),
+    };
+    let tol = Tolerance {
+        plus: operand1_max + operand2_max,
+        minus: operand1_min + operand2_min,
+    };
+
+    (result, Some(tol))
+}
+
+pub fn calculate_division_with_tolerance<M: Measurement, N: Measurement>(
+    factor1: &M,
+    factor2: &N,
+) -> (f64, Option<Tolerance>) {
+    if factor2.get_nominal_value() == 0.0 {
+        panic!("Division by zero is not allowed.");
+    }
+
+    let operand1_nom = factor1.get_nominal_value();
+    let operand2_nom = factor2.get_nominal_value();
+
+    let result = operand1_nom / operand2_nom;
+
+    let operand1_tol = factor1.get_tolerance();
+    let operand2_tol = factor2.get_tolerance();
+
+    if operand1_tol.is_none() && operand2_tol.is_none() {
+        return (result, None);
+    }
+
+    let (operand1_min, operand1_max) = match operand1_tol {
+        Some(tol) => (tol.minus, tol.plus),
+        None => (0.0, 0.0),
+    };
+
+    let (operand2_min, operand2_max) = match operand2_tol {
+        Some(tol) => (tol.minus, tol.plus),
+        None => (0.0, 0.0),
+    };
+
+    let tol = Tolerance {
+        plus: operand1_max + operand2_min,
+        minus: operand1_min + operand2_max,
+    };
+
+    (result, Some(tol))
+}
+
+pub fn calculate_addition_with_tolerance<M: Measurement, N: Measurement>(
+    factor1: &M,
+    factor2: &N,
+) -> (f64, Option<Tolerance>) {
+    let operand1_nom = factor1.get_nominal_value();
+    let operand2_nom = factor2.get_nominal_value();
+
+    let result = operand1_nom + operand2_nom;
+
+    let operand1_tol = factor1.get_tolerance();
+    let operand2_tol = factor2.get_tolerance();
+
+    if operand1_tol.is_none() && operand2_tol.is_none() {
+        return (result, None);
+    }
+
+    let (operand1_min, operand1_max) = match operand1_tol {
+        Some(tol) => (
+            operand1_nom - operand1_nom * (1.0 - tol.minus / 100.0),
+            operand1_nom * (1.0 + tol.plus / 100.0) - operand1_nom,
+        ),
+        None => (0.0, 0.0),
+    };
+
+    let (operand2_min, operand2_max) = match operand2_tol {
+        Some(tol) => (
+            operand2_nom - operand2_nom * (1.0 - tol.minus / 100.0),
+            operand2_nom * (1.0 + tol.plus / 100.0) - operand2_nom,
+        ),
+        None => (0.0, 0.0),
+    };
+
+    let max_result = operand1_max + operand2_max;
+    let min_result = operand1_min + operand2_min;
+
+    let tol_plus = (max_result / result) * 100.0;
+    let tol_minus = (min_result / result) * 100.0;
+
+    let tol = Tolerance {
+        plus: tol_plus,
+        minus: tol_minus,
+    };
+
+    (result, Some(tol))
+}
+
+pub fn calculate_subtraction_with_tolerance<M: Measurement, N: Measurement>(
+    factor1: &M,
+    factor2: &N,
+) -> (f64, Option<Tolerance>) {
+    let operand1_nom = factor1.get_nominal_value();
+    let operand2_nom = factor2.get_nominal_value();
+
+    let result = operand1_nom - operand2_nom;
+
+    let operand1_tol = factor1.get_tolerance();
+    let operand2_tol = factor2.get_tolerance();
+
+    if operand1_tol.is_none() && operand2_tol.is_none() {
+        return (result, None);
+    }
+
+    let (operand1_min, operand1_max) = match operand1_tol {
+        Some(tol) => (
+            operand1_nom - operand1_nom * (1.0 - tol.minus / 100.0),
+            operand1_nom * (1.0 + tol.plus / 100.0) - operand1_nom,
+        ),
+        None => (0.0, 0.0),
+    };
+
+    let (operand2_min, operand2_max) = match operand2_tol {
+        Some(tol) => (
+            operand2_nom - operand2_nom * (1.0 - tol.minus / 100.0),
+            operand2_nom * (1.0 + tol.plus / 100.0) - operand2_nom,
+        ),
+        None => (0.0, 0.0),
+    };
+
+    let max_result = operand1_max + operand2_max;
+    let min_result = operand1_min + operand2_min;
+
+    let tol_plus = (max_result / result) * 100.0;
+    let tol_minus = (min_result / result) * 100.0;
+
+    let tol = Tolerance {
+        plus: tol_plus,
+        minus: tol_minus,
+    };
+
+    (result, Some(tol))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trait_measurement() {
+        struct Test;
+
+        impl Measurement for Test {
+            fn get_nominal_value(&self) -> f64 {
+                220.0
+            }
+
+            fn get_tolerance(&self) -> Option<Tolerance> {
+                Some(Tolerance {
+                    plus: 5.0,
+                    minus: 3.3,
+                })
+            }
+
+            fn get_unit(&self) -> &'static str {
+                "TEST"
+            }
+        }
+
+        let test = Test;
+
+        assert_eq!(test.get_unit(), "TEST");
+        assert_eq!(
+            test.get_tolerance(),
+            Some(Tolerance {
+                plus: 5.0,
+                minus: 3.3
+            })
+        );
+        assert_eq!(test.get_nominal_value(), 220.0);
+        assert_eq!(test.get_value_nom(), "220.00TEST");
+        assert_eq!(test.get_value_min(), "212.74TEST");
+        assert_eq!(test.get_value_max(), "231.00TEST");
+        assert_eq!(test.get_tol_value_plus(), "11.00TEST");
+        assert_eq!(test.get_tol_value_minus(), "-7.26TEST");
+        assert_eq!(test.get_tol_percent_plus(), "5.00%");
+        assert_eq!(test.get_tol_percent_minus(), "-3.30%");
+    }
+
+    #[test]
+    fn test_trait_calculation() {
+        struct Value1;
+        impl Measurement for Value1 {
+            fn get_nominal_value(&self) -> f64 {
+                300.0
+            }
+
+            fn get_tolerance(&self) -> Option<Tolerance> {
+                Some(Tolerance {
+                    plus: 5.0,
+                    minus: 3.3,
+                })
+            }
+
+            fn get_unit(&self) -> &'static str {
+                "V1"
+            }
+        }
+
+        let value1 = Value1;
+
+        struct Value2;
+        impl Measurement for Value2 {
+            fn get_nominal_value(&self) -> f64 {
+                150.0
+            }
+
+            fn get_tolerance(&self) -> Option<Tolerance> {
+                Some(Tolerance {
+                    plus: 1.0,
+                    minus: 2.5,
+                })
+            }
+
+            fn get_unit(&self) -> &'static str {
+                "V2"
+            }
+        }
+
+        let value2 = Value2;
+
+        // *
+        let a = calculate_multiplication_with_tolerance(&value1, &value2);
+        assert_eq!(a.0, 45000.0);
+        assert_eq!(
+            a.1,
+            Some(Tolerance {
+                plus: 6.0,
+                minus: 5.8
+            })
+        );
+        // /
+        let b = calculate_division_with_tolerance(&value1, &value2);
+        assert_eq!(b.0, 2.0);
+        assert_eq!(
+            b.1,
+            Some(Tolerance {
+                plus: 7.5,
+                minus: 4.3
+            })
+        );
+        // +
+        let c = calculate_addition_with_tolerance(&value1, &value2);
+        assert_eq!(c.0, 450.0);
+        assert_eq!(
+            c.1,
+            Some(Tolerance {
+                plus: 3.6666666666666665,
+                minus: 3.033333333333341
+            })
+        );
+        // -
+        let d = calculate_subtraction_with_tolerance(&value1, &value2);
+        assert_eq!(d.0, 150.0);
+        assert_eq!(
+            d.1,
+            Some(Tolerance {
+                plus: 11.0,
+                minus: 9.100000000000023
+            })
+        );
+
+        struct Value3;
+        impl Measurement for Value3 {
+            fn get_nominal_value(&self) -> f64 {
+                150.0
+            }
+
+            fn get_tolerance(&self) -> Option<Tolerance> {
+                None
+            }
+
+            fn get_unit(&self) -> &'static str {
+                "V3"
+            }
+        }
+
+        let value3 = Value3;
+
+        // *
+        let a = calculate_multiplication_with_tolerance(&value1, &value3);
+        assert_eq!(a.0, 45000.0);
+        assert_eq!(
+            a.1,
+            Some(Tolerance {
+                plus: 5.0,
+                minus: 3.3
+            })
+        );
+
+        // /
+        let b = calculate_division_with_tolerance(&value1, &value3);
+        assert_eq!(b.0, 2.0);
+        assert_eq!(
+            b.1,
+            Some(Tolerance {
+                plus: 5.0,
+                minus: 3.3
+            })
+        );
+
+        // +
+        let c = calculate_addition_with_tolerance(&value1, &value3);
+        assert_eq!(c.0, 450.0);
+        assert_eq!(
+            c.1,
+            Some(Tolerance {
+                plus: 3.3333333333333335,
+                minus: 2.2000000000000073
+            })
+        );
+
+        // -
+        let d = calculate_subtraction_with_tolerance(&value1, &value3);
+        assert_eq!(d.0, 150.0);
+        assert_eq!(
+            d.1,
+            Some(Tolerance {
+                plus: 10.0,
+                minus: 6.600000000000023
+            })
+        );
+    }
+}

--- a/src/types/power.rs
+++ b/src/types/power.rs
@@ -1,0 +1,148 @@
+use crate::types::{
+    calculate_division_with_tolerance, calculate_multiplication_with_tolerance, current::Current,
+    resistance::Resistance, voltage::Voltage, Measurement, ParserError, Tolerance,
+};
+use crate::{parser, parser::Block};
+use std::{
+    ops::{Div, Mul},
+    str::FromStr,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Power {
+    pub value: f64,
+    pub tolerance: Option<Tolerance>,
+}
+
+impl Default for Power {
+    fn default() -> Self {
+        Self {
+            value: 0.0,
+            tolerance: None,
+        }
+    }
+}
+
+impl Measurement for Power {
+    fn get_nominal_value(&self) -> f64 {
+        self.value
+    }
+
+    fn get_tolerance(&self) -> Option<Tolerance> {
+        self.tolerance
+    }
+
+    fn get_unit(&self) -> &'static str {
+        "W"
+    }
+}
+
+impl FromStr for Power {
+    type Err = ParserError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let input = input.trim();
+        if input.trim().is_empty() {
+            return Err(ParserError::EmptyInput);
+        }
+
+        match parser::parse_blocks(input) {
+            Ok((input, result)) => {
+                // If there is any remaining unparsed input, it's an error
+                if !input.is_empty() {
+                    return Err(ParserError::IncorrectInput(input.to_string()));
+                }
+
+                let mut value = f64::NAN;
+                let mut tol: Option<Tolerance> = None;
+
+                // Process each parsed block
+                for block in result {
+                    match block {
+                        Block::Number(n) => value = n,
+                        Block::NumberSuffix((n, s)) => value = n * s.coefficient(),
+                        Block::TolMinus(t) => {
+                            tol = if let Some(tt) = tol {
+                                Some(Tolerance {
+                                    plus: tt.plus,
+                                    minus: t,
+                                })
+                            } else {
+                                Some(Tolerance {
+                                    plus: 0.0,
+                                    minus: t,
+                                })
+                            };
+                        }
+                        Block::TolPlus(t) => {
+                            tol = if let Some(tt) = tol {
+                                Some(Tolerance {
+                                    plus: t,
+                                    minus: tt.minus,
+                                })
+                            } else {
+                                Some(Tolerance {
+                                    plus: t,
+                                    minus: 0.0,
+                                })
+                            };
+                        }
+                        Block::TolPlusMinus(t) => {
+                            tol = Some(Tolerance { plus: t, minus: t });
+                        }
+                    }
+                }
+
+                Ok(Power {
+                    value,
+                    tolerance: tol,
+                })
+            }
+            Err(e) => Err(ParserError::IncorrectInput(e.to_string())),
+        }
+    }
+}
+
+impl Div<Voltage> for Power {
+    type Output = Current;
+
+    fn div(self, rhs: Voltage) -> Self::Output {
+        let (value, tol) = calculate_division_with_tolerance(&self, &rhs);
+
+        Current {
+            value: value,
+            tolerance: tol,
+        }
+    }
+}
+
+impl Div<Current> for Power {
+    type Output = Resistance;
+
+    fn div(self, rhs: Current) -> Self::Output {
+        let current2 = calculate_multiplication_with_tolerance(&rhs, &rhs);
+        let current2 = Current {
+            value: current2.0,
+            tolerance: current2.1,
+        };
+        let (value, tol) = calculate_division_with_tolerance(&self, &current2);
+
+        Resistance {
+            value: value,
+            tolerance: tol,
+        }
+    }
+}
+
+impl Mul<Current> for Power {
+    type Output = Voltage;
+
+    fn mul(self, rhs: Current) -> Self::Output {
+        let (value, tol) = calculate_division_with_tolerance(&self, &rhs);
+
+        Voltage {
+            value: value,
+            tolerance: tol,
+        }
+    }
+}

--- a/src/types/resistance.rs
+++ b/src/types/resistance.rs
@@ -1,0 +1,142 @@
+use crate::types::{
+    calculate_addition_with_tolerance, calculate_division_with_tolerance,
+    calculate_multiplication_with_tolerance, current::Current, power::Power, Measurement,
+    ParserError, Tolerance,
+};
+use crate::{parser, parser::Block};
+use std::{ops::Add, ops::AddAssign, ops::Mul, str::FromStr};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Resistance {
+    pub value: f64,
+    pub tolerance: Option<Tolerance>,
+}
+
+impl Default for Resistance {
+    fn default() -> Self {
+        Self {
+            value: 0.0,
+            tolerance: None,
+        }
+    }
+}
+
+impl Measurement for Resistance {
+    fn get_nominal_value(&self) -> f64 {
+        self.value
+    }
+
+    fn get_tolerance(&self) -> Option<Tolerance> {
+        self.tolerance
+    }
+
+    fn get_unit(&self) -> &'static str {
+        "R"
+    }
+}
+
+impl FromStr for Resistance {
+    type Err = ParserError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let input = input.trim();
+        if input.trim().is_empty() {
+            return Err(ParserError::EmptyInput);
+        }
+
+        match parser::parse_blocks(input) {
+            Ok((input, result)) => {
+                // If there is any remaining unparsed input, it's an error
+                if !input.is_empty() {
+                    return Err(ParserError::IncorrectInput(input.to_string()));
+                }
+
+                let mut value = f64::NAN;
+                let mut tol: Option<Tolerance> = None;
+
+                // Process each parsed block
+                for block in result {
+                    match block {
+                        Block::Number(n) => value = n,
+                        Block::NumberSuffix((n, s)) => value = n * s.coefficient(),
+                        Block::TolMinus(t) => {
+                            tol = if let Some(tt) = tol {
+                                Some(Tolerance {
+                                    plus: tt.plus,
+                                    minus: t,
+                                })
+                            } else {
+                                Some(Tolerance {
+                                    plus: 0.0,
+                                    minus: t,
+                                })
+                            };
+                        }
+                        Block::TolPlus(t) => {
+                            tol = if let Some(tt) = tol {
+                                Some(Tolerance {
+                                    plus: t,
+                                    minus: tt.minus,
+                                })
+                            } else {
+                                Some(Tolerance {
+                                    plus: t,
+                                    minus: 0.0,
+                                })
+                            };
+                        }
+                        Block::TolPlusMinus(t) => {
+                            tol = Some(Tolerance { plus: t, minus: t });
+                        }
+                    }
+                }
+
+                Ok(Resistance {
+                    value,
+                    tolerance: tol,
+                })
+            }
+            Err(e) => Err(ParserError::IncorrectInput(e.to_string())),
+        }
+    }
+}
+
+impl AddAssign for Resistance {
+    fn add_assign(&mut self, rhs: Self) {
+        let result = calculate_addition_with_tolerance(self, &rhs);
+
+        self.value = result.0;
+        self.tolerance = result.1;
+    }
+}
+
+impl Add for Resistance {
+    type Output = Resistance;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let result = calculate_addition_with_tolerance(&self, &rhs);
+
+        Resistance {
+            value: result.0,
+            tolerance: result.1,
+        }
+    }
+}
+
+impl Mul<Current> for Resistance {
+    type Output = Power;
+
+    fn mul(self, rhs: Current) -> Self::Output {
+        let current2 = calculate_multiplication_with_tolerance(&rhs, &rhs);
+        let current2 = Current {
+            value: current2.0,
+            tolerance: current2.1,
+        };
+        let (value, tol) = calculate_division_with_tolerance(&current2, &self);
+
+        Power {
+            value: value,
+            tolerance: tol,
+        }
+    }
+}

--- a/src/types/voltage.rs
+++ b/src/types/voltage.rs
@@ -1,0 +1,297 @@
+use crate::{
+    parser,
+    parser::Block,
+    types::{
+        calculate_addition_with_tolerance, calculate_division_with_tolerance,
+        calculate_multiplication_with_tolerance, calculate_subtraction_with_tolerance,
+        current::Current, power::Power, resistance::Resistance, Measurement, ParserError,
+        Tolerance,
+    },
+};
+
+use std::{
+    ops::{Add, Div, Mul, Sub},
+    str::FromStr,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Voltage {
+    pub value: f64,
+    pub tolerance: Option<Tolerance>,
+}
+
+impl Default for Voltage {
+    fn default() -> Self {
+        Self {
+            value: 0.0,
+            tolerance: None,
+        }
+    }
+}
+
+impl Measurement for Voltage {
+    fn get_nominal_value(&self) -> f64 {
+        self.value
+    }
+
+    fn get_tolerance(&self) -> Option<Tolerance> {
+        self.tolerance
+    }
+
+    fn get_unit(&self) -> &'static str {
+        "V"
+    }
+}
+
+impl FromStr for Voltage {
+    type Err = ParserError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let input = input.trim();
+        if input.trim().is_empty() {
+            return Err(ParserError::EmptyInput);
+        }
+
+        match parser::parse_blocks(input) {
+            Ok((input, result)) => {
+                // If there is any remaining unparsed input, it's an error
+                if !input.is_empty() {
+                    return Err(ParserError::IncorrectInput(input.to_string()));
+                }
+
+                let mut value = f64::NAN;
+                let mut tol: Option<Tolerance> = None;
+
+                // Process each parsed block
+                for block in result {
+                    match block {
+                        Block::Number(n) => value = n,
+                        Block::NumberSuffix((n, s)) => value = n * s.coefficient(),
+                        Block::TolMinus(t) => {
+                            tol = if let Some(tt) = tol {
+                                Some(Tolerance {
+                                    plus: tt.plus,
+                                    minus: t,
+                                })
+                            } else {
+                                Some(Tolerance {
+                                    plus: 0.0,
+                                    minus: t,
+                                })
+                            };
+                        }
+                        Block::TolPlus(t) => {
+                            tol = if let Some(tt) = tol {
+                                Some(Tolerance {
+                                    plus: t,
+                                    minus: tt.minus,
+                                })
+                            } else {
+                                Some(Tolerance {
+                                    plus: t,
+                                    minus: 0.0,
+                                })
+                            };
+                        }
+                        Block::TolPlusMinus(t) => {
+                            tol = Some(Tolerance { plus: t, minus: t });
+                        }
+                    }
+                }
+
+                Ok(Voltage {
+                    value,
+                    tolerance: tol,
+                })
+            }
+            Err(e) => Err(ParserError::IncorrectInput(e.to_string())),
+        }
+    }
+}
+
+impl Add for Voltage {
+    type Output = Voltage;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let result = calculate_addition_with_tolerance(&self, &rhs);
+
+        Voltage {
+            value: result.0,
+            tolerance: result.1,
+        }
+    }
+}
+
+impl Sub for Voltage {
+    type Output = Voltage;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        let result = calculate_subtraction_with_tolerance(&self, &rhs);
+
+        Voltage {
+            value: result.0,
+            tolerance: result.1,
+        }
+    }
+}
+
+impl Div<Current> for Voltage {
+    type Output = Resistance;
+
+    fn div(self, rhs: Current) -> Self::Output {
+        let (value, tol) = calculate_division_with_tolerance(&self, &rhs);
+
+        Resistance {
+            value: value,
+            tolerance: tol,
+        }
+    }
+}
+
+impl Div<Power> for Voltage {
+    type Output = Resistance;
+
+    fn div(self, rhs: Power) -> Self::Output {
+        let voltage2 = calculate_multiplication_with_tolerance(&self, &self);
+        let voltage2 = Voltage {
+            value: voltage2.0,
+            tolerance: voltage2.1,
+        };
+        let (value, tol) = calculate_division_with_tolerance(&voltage2, &rhs);
+
+        Resistance {
+            value: value,
+            tolerance: tol,
+        }
+    }
+}
+
+impl Div<Resistance> for Voltage {
+    type Output = Current;
+
+    fn div(self, rhs: Resistance) -> Self::Output {
+        let (value, tol) = calculate_division_with_tolerance(&self, &rhs);
+
+        Current {
+            value: value,
+            tolerance: tol,
+        }
+    }
+}
+
+impl Mul<Current> for Voltage {
+    type Output = Power;
+
+    fn mul(self, rhs: Current) -> Self::Output {
+        let (value, tol) = calculate_multiplication_with_tolerance(&self, &rhs);
+
+        Power {
+            value: value,
+            tolerance: tol,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_voltage_parser() {
+        //assert_eq!("12p".parse::<Voltage>(), Ok(Voltage { value: 1.2e-11, tolerance: None }));
+        //assert_eq!("12n".parse::<Voltage>(), Ok(Voltage { value: 12e-9, tolerance: None }));
+        assert_eq!(
+            "12u".parse::<Voltage>(),
+            Ok(Voltage {
+                value: 12e-6,
+                tolerance: None
+            })
+        );
+        assert_eq!(
+            "12m".parse::<Voltage>(),
+            Ok(Voltage {
+                value: 12e-3,
+                tolerance: None
+            })
+        );
+        assert_eq!(
+            "12".parse::<Voltage>(),
+            Ok(Voltage {
+                value: 12.0,
+                tolerance: None
+            })
+        );
+        assert_eq!(
+            "12k".parse::<Voltage>(),
+            Ok(Voltage {
+                value: 12e3,
+                tolerance: None
+            })
+        );
+        assert_eq!(
+            "12M".parse::<Voltage>(),
+            Ok(Voltage {
+                value: 12e6,
+                tolerance: None
+            })
+        );
+        assert_eq!(
+            "12G".parse::<Voltage>(),
+            Ok(Voltage {
+                value: 12e9,
+                tolerance: None
+            })
+        );
+        assert_eq!(
+            "12T".parse::<Voltage>(),
+            Ok(Voltage {
+                value: 12e12,
+                tolerance: None
+            })
+        );
+    }
+
+    #[test]
+    fn test_voltage_with_tolerance_parser() {
+        assert_eq!(
+            "12 +5%".parse::<Voltage>(),
+            Ok(Voltage {
+                value: 12.0,
+                tolerance: Some(Tolerance {
+                    plus: 5.0,
+                    minus: 0.0
+                })
+            })
+        );
+        assert_eq!(
+            "12 -5%".parse::<Voltage>(),
+            Ok(Voltage {
+                value: 12.0,
+                tolerance: Some(Tolerance {
+                    plus: 0.0,
+                    minus: 5.0
+                })
+            })
+        );
+        assert_eq!(
+            "12 5.25%".parse::<Voltage>(),
+            Ok(Voltage {
+                value: 12.0,
+                tolerance: Some(Tolerance {
+                    plus: 5.25,
+                    minus: 5.25
+                })
+            })
+        );
+        assert_eq!(
+            "12 +5% -3%".parse::<Voltage>(),
+            Ok(Voltage {
+                value: 12.0,
+                tolerance: Some(Tolerance {
+                    plus: 5.0,
+                    minus: 3.0
+                })
+            })
+        );
+    }
+}

--- a/src/voltage_divider/mod.rs
+++ b/src/voltage_divider/mod.rs
@@ -1,0 +1,547 @@
+use crate::types::{current::Current, power::Power, resistance::Resistance, voltage::Voltage};
+use crate::types::{Measurement, ParserError};
+use iced::widget::{Button, Column, Container, Row, Rule, Scrollable, Text, TextInput};
+use iced::{Color, Element, Fill};
+
+#[derive(Debug, Clone)]
+pub struct VoltageDivider {
+    legs: Vec<Leg>,
+}
+
+impl Default for VoltageDivider {
+    fn default() -> Self {
+        let legs = vec![Leg::default(), Leg::default()];
+
+        Self { legs: legs }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Leg {
+    resistance_raw: String,
+    voltage_raw: String,
+    voltage: Result<Voltage, ParserError>,
+    current: Result<Current, ParserError>,
+    resistance: Result<Resistance, ParserError>,
+    power: Result<Power, ParserError>,
+}
+
+impl Default for Leg {
+    fn default() -> Self {
+        Self {
+            resistance_raw: String::new(),
+            voltage_raw: String::new(),
+            voltage: Err(ParserError::EmptyInput),
+            current: Err(ParserError::EmptyInput),
+            resistance: Err(ParserError::EmptyInput),
+            power: Err(ParserError::EmptyInput),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    InputVoltageChanged(usize, String),
+    InputResistanceChanged(usize, String),
+    LegAdd,
+    LegDelete(usize),
+}
+
+impl VoltageDivider {
+    pub fn title(&self) -> String {
+        String::from("Voltage Divider")
+    }
+
+    pub fn view(&self) -> Element<Message> {
+        Column::new()
+            .push(self.view_form())
+            .push(self.view_result())
+            .into()
+    }
+
+    fn view_result(&self) -> Element<Message> {
+        fn format_measurement<T: Measurement, E>(data: Result<T, E>) -> (String, String, String) {
+            match data {
+                Ok(measurement) => (
+                    measurement.get_value_nom(),
+                    measurement.get_value_min(),
+                    measurement.get_value_max(),
+                ),
+                Err(_) => ("N/A".to_string(), "N/A".to_string(), "N/A".to_string()),
+            }
+        }
+        fn format_tol<T: Measurement, E>(data: Result<T, E>) -> (String, String, String, String) {
+            match data {
+                Ok(measurement) => (
+                    measurement.get_tol_value_plus(),
+                    measurement.get_tol_value_minus(),
+                    measurement.get_tol_percent_plus(),
+                    measurement.get_tol_percent_minus(),
+                ),
+                Err(_) => (
+                    "N/A".to_string(),
+                    "N/A".to_string(),
+                    "N/A".to_string(),
+                    "N/A".to_string(),
+                ),
+            }
+        }
+
+        let mut data: Vec<(String, Vec<Vec<String>>)> = Vec::new();
+        for (id, leg) in self.legs.iter().enumerate() {
+            let (voltage_nom, voltage_min, voltage_max) = format_measurement(leg.voltage.clone());
+            let (voltage_tol_plus, voltage_tol_minus, voltage_tol_plus_p, voltage_tol_minus_p) =
+                format_tol(leg.voltage.clone());
+
+            let (current_nom, current_min, current_max) = format_measurement(leg.current.clone());
+            let (current_tol_plus, current_tol_minus, current_tol_plus_p, current_tol_minus_p) =
+                format_tol(leg.current.clone());
+
+            let (resistance_nom, resistance_min, resistance_max) =
+                format_measurement(leg.resistance.clone());
+            let (
+                resistance_tol_plus,
+                resistance_tol_minus,
+                resistance_tol_plus_p,
+                resistance_tol_minus_p,
+            ) = format_tol(leg.resistance.clone());
+
+            let (power_nom, power_min, power_max) = format_measurement(leg.power.clone());
+            let (power_tol_plus, power_tol_minus, power_tol_plus_p, power_tol_minus_p) =
+                format_tol(leg.power.clone());
+
+            let iter_data: Vec<Vec<String>> = vec![
+                vec![
+                    "Value nom".to_string(),
+                    voltage_nom,
+                    current_nom,
+                    resistance_nom,
+                    power_nom,
+                ],
+                vec![
+                    "Value max".to_string(),
+                    voltage_max,
+                    current_max,
+                    resistance_max,
+                    power_max,
+                ],
+                vec![
+                    "Value min".to_string(),
+                    voltage_min,
+                    current_min,
+                    resistance_min,
+                    power_min,
+                ],
+                vec![
+                    "Tol plus".to_string(),
+                    voltage_tol_plus,
+                    current_tol_plus,
+                    resistance_tol_plus,
+                    power_tol_plus,
+                ],
+                vec![
+                    "Tol minus".to_string(),
+                    voltage_tol_minus,
+                    current_tol_minus,
+                    resistance_tol_minus,
+                    power_tol_minus,
+                ],
+                vec![
+                    "Tol plus, %".to_string(),
+                    voltage_tol_plus_p,
+                    current_tol_plus_p,
+                    resistance_tol_plus_p,
+                    power_tol_plus_p,
+                ],
+                vec![
+                    "Tol minus, %".to_string(),
+                    voltage_tol_minus_p,
+                    current_tol_minus_p,
+                    resistance_tol_minus_p,
+                    power_tol_minus_p,
+                ],
+            ];
+            let collect = (format!("R{}", id + 1), iter_data);
+
+            data.push(collect);
+        }
+
+        self.view_table(data).into()
+    }
+
+    fn view_table(&self, table_data: Vec<(String, Vec<Vec<String>>)>) -> Element<Message> {
+        const BORDER_WIDTH: u16 = 0;
+        const FIRST_COLUMN_WIDTH: u16 = 110;
+
+        fn create_text_cell(content: String) -> Element<'static, Message> {
+            let text = Text::new(content).width(Fill);
+
+            Container::new(text).padding(5).into()
+        }
+
+        fn create_table_row(
+            cell_1: String,
+            cell_2: String,
+            cell_3: String,
+            cell_4: String,
+            cell_5: String,
+        ) -> Element<'static, Message> {
+            Row::new()
+                .push(Rule::vertical(BORDER_WIDTH))
+                .push(Container::new(create_text_cell(cell_1)).width(FIRST_COLUMN_WIDTH))
+                .push(Rule::vertical(BORDER_WIDTH))
+                .push(Text::new("").width(1)) // Double border line
+                .push(Rule::vertical(BORDER_WIDTH))
+                .push(create_text_cell(cell_2))
+                .push(Rule::vertical(BORDER_WIDTH))
+                .push(create_text_cell(cell_3))
+                .push(Rule::vertical(BORDER_WIDTH))
+                .push(create_text_cell(cell_4))
+                .push(Rule::vertical(BORDER_WIDTH))
+                .push(create_text_cell(cell_5))
+                .push(Rule::vertical(BORDER_WIDTH))
+                .height(30)
+                .width(Fill)
+                .into()
+        }
+
+        let mut table_sections = Vec::new();
+        // header
+        let header = Row::new()
+            .push(Rule::vertical(BORDER_WIDTH))
+            .push(Container::new(create_text_cell("".to_string())).width(50 + FIRST_COLUMN_WIDTH))
+            .push(Rule::vertical(BORDER_WIDTH))
+            .push(Text::new("").width(1)) // Double border line
+            .push(Rule::vertical(BORDER_WIDTH))
+            .push(create_text_cell("Voltage".to_string()))
+            .push(Rule::vertical(BORDER_WIDTH))
+            .push(create_text_cell("Current".to_string()))
+            .push(Rule::vertical(BORDER_WIDTH))
+            .push(create_text_cell("Resistance".to_string()))
+            .push(Rule::vertical(BORDER_WIDTH))
+            .push(create_text_cell("Power".to_string()))
+            .push(Rule::vertical(BORDER_WIDTH))
+            .push(Text::new("").width(15)) // padding for Scrollable
+            .height(30)
+            .width(Fill)
+            .into();
+        table_sections.push(Rule::horizontal(BORDER_WIDTH).into());
+        table_sections.push(header);
+
+        // data
+        for (section_label, rows) in table_data {
+            let mut row_elements = Vec::new();
+
+            for row_cells in rows {
+                let row = create_table_row(
+                    row_cells[0].clone(),
+                    row_cells[1].clone(),
+                    row_cells[2].clone(),
+                    row_cells[3].clone(),
+                    row_cells[4].clone(),
+                );
+                row_elements.push(Rule::horizontal(BORDER_WIDTH).into());
+                row_elements.push(row);
+            }
+            row_elements.push(Rule::horizontal(BORDER_WIDTH).into());
+
+            let section_content = Column::from_vec(row_elements).width(Fill);
+
+            let section_label_column = Column::new()
+                .push(Rule::horizontal(BORDER_WIDTH))
+                .push(
+                    Container::new(create_text_cell(section_label))
+                        .height(Fill)
+                        .align_y(iced::Alignment::Center),
+                )
+                .push(Rule::horizontal(BORDER_WIDTH))
+                .width(50);
+
+            let section_row = Row::new()
+                .push(Rule::vertical(BORDER_WIDTH))
+                .push(section_label_column)
+                .push(Rule::vertical(BORDER_WIDTH))
+                .push(section_content)
+                .push(Text::new("").width(15)) // padding for Scrollable
+                .height(210);
+
+            table_sections.push(section_row.into());
+        }
+
+        let table_layout = Column::from_vec(table_sections).padding([5, 0]).width(Fill);
+
+        Scrollable::new(table_layout).height(Fill).into()
+    }
+
+    fn view_form(&self) -> Element<Message> {
+        let mut elements = Vec::new();
+        for (id, leg) in self.legs.iter().enumerate() {
+            let label1_text = format!("R{}", id + 1);
+            let label2_text = format!("U{}", id + 1);
+            let delete = if id <= 1 { false } else { true };
+            let under_text = match (&self.legs[id].resistance, &self.legs[id].voltage) {
+                // Некорректный ввод сопротивления и напряжения
+                (Err(ParserError::IncorrectInput(e1)), Err(ParserError::IncorrectInput(e2))) => {
+                    format!(
+                        "Resistance field error: {}; Voltage field error: {}",
+                        e1, e2
+                    )
+                }
+                // Некорректный ввод сопротивления, напряжение корректно
+                (Err(ParserError::IncorrectInput(e1)), Ok(_)) => {
+                    format!("Resistance field error: {}", e1)
+                }
+                // Сопротивление корректно, некорректный ввод напряжения
+                (Ok(_), Err(ParserError::IncorrectInput(e2))) => {
+                    format!("Voltage field error: {}", e2)
+                }
+                // Пустой ввод сопротивления и напряжения
+                (Err(ParserError::EmptyInput), Err(ParserError::EmptyInput)) => {
+                    String::from("Both resistance and voltage fields are empty.")
+                }
+                // Пустой ввод сопротивления, напряжение корректно
+                (Err(ParserError::EmptyInput), Ok(_)) => String::from("Resistance field is empty."),
+                // Сопротивление корректно, пустой ввод напряжения
+                (Ok(_), Err(ParserError::EmptyInput)) => String::from("Voltage field is empty."),
+                // Все корректно
+                (Ok(_), Ok(_)) => String::from("All fields are correct."),
+                // Пример по умолчанию
+                _ => String::from("Example: 1k 5%"),
+            };
+
+            let field = self.create_input_field(
+                id,
+                label1_text,
+                &leg.resistance_raw,
+                label2_text,
+                &leg.voltage_raw,
+                under_text,
+                delete,
+            );
+            elements.push(field);
+        }
+
+        let label = Container::new(Text::new("Add leg")).center_x(Fill);
+        let button = Button::new(label)
+            .on_press(Message::LegAdd)
+            .width(Fill)
+            .into();
+        elements.push(button);
+
+        Column::from_vec(elements)
+            .padding([5, 0])
+            .width(Fill)
+            .into()
+    }
+
+    fn create_input_field<'a>(
+        &self,
+        leg_id: usize,
+        label1_text: String,
+        input1_value: &'a str,
+        label2_text: String,
+        input2_value: &'a str,
+        under_text: String,
+        delete_button_view: bool,
+    ) -> Element<'a, Message> {
+        let label1 = Text::new(label1_text)
+            .height(30)
+            .width(30)
+            .align_y(iced::Alignment::Center);
+        let input1 = TextInput::new("", input1_value)
+            .on_input(move |s| Message::InputResistanceChanged(leg_id, s));
+        let label2 = Text::new(label2_text)
+            .height(30)
+            .width(30)
+            .align_y(iced::Alignment::Center);
+        let input2 = TextInput::new("", input2_value)
+            .on_input(move |s| Message::InputVoltageChanged(leg_id, s));
+        let button1: Element<Message> = if delete_button_view == true {
+            Button::new(Text::new("−").size(16))
+                .on_press(Message::LegDelete(leg_id))
+                .width(30)
+                .height(30)
+                .into()
+        } else {
+            Text::new("").width(30).into()
+        };
+        let button1 = Row::new().push(Text::new("").width(5)).push(button1);
+
+        let row1 = Row::new()
+            .push(label1)
+            .push(input1)
+            .push(Text::new("").width(50))
+            .push(label2)
+            .push(input2)
+            .push(button1);
+
+        let row2 = Row::new().push(Text::new("").width(30)).push(
+            Text::new(under_text)
+                .color(Color::from_rgb8(128, 128, 128))
+                .size(12),
+        );
+
+        Column::new().push(row1).push(row2).into()
+    }
+
+    pub fn update(&mut self, message: Message) {
+        match message {
+            Message::InputResistanceChanged(id, s) => {
+                self.legs[id].resistance_raw = s;
+                self.legs[id].resistance = self.legs[id].resistance_raw.parse::<Resistance>();
+            }
+            Message::InputVoltageChanged(id, s) => {
+                self.legs[id].voltage_raw = s;
+                self.legs[id].voltage = self.legs[id].voltage_raw.parse::<Voltage>();
+            }
+            Message::LegAdd => self.legs.push(Leg::default()),
+            Message::LegDelete(id) => {
+                let _leg = self.legs.remove(id);
+            }
+        }
+
+        // кажется нужно очищать значения если нет пользовательского ввода
+        for leg in &mut self.legs.iter_mut() {
+            if leg.voltage_raw.is_empty() {
+                leg.voltage = Err(ParserError::EmptyInput);
+                leg.power = Err(ParserError::EmptyInput);
+                leg.current = Err(ParserError::EmptyInput);
+            }
+            if leg.resistance_raw.is_empty() {
+                leg.resistance = Err(ParserError::EmptyInput);
+                leg.power = Err(ParserError::EmptyInput);
+                leg.current = Err(ParserError::EmptyInput);
+            }
+        }
+
+        let mut v1: Option<Voltage> = None;
+        let mut v2: Option<Voltage> = None;
+        let mut r_sum: Option<Resistance> = None;
+        let mut empty_fields = false;
+
+        for leg in self.legs.iter().rev() {
+            match (leg.resistance.clone(), leg.voltage.clone()) {
+                (Err(_), Err(_)) => {
+                    v1 = None;
+                    v2 = None;
+                    r_sum = None;
+                    empty_fields = true;
+                }
+                (Ok(r), Ok(v)) => {
+                    v2 = Some(v);
+                    r_sum = if let Some(rr) = r_sum {
+                        Some(r + rr)
+                    } else {
+                        Some(r)
+                    };
+                }
+                (Err(_), Ok(v)) => {
+                    v1 = Some(v);
+                }
+                (Ok(r), Err(_)) => {
+                    if v2.is_none() {
+                        r_sum = if let Some(rr) = r_sum {
+                            Some(r + rr)
+                        } else {
+                            Some(r)
+                        };
+                    }
+                }
+            }
+        }
+
+        // если второе напряжение не определено, то принимаем его за 0
+        if v1.is_none() {
+            v1 = Some(Voltage::default());
+        }
+
+        let current = if let (Some(v1), Some(v2), Some(r)) = (v1, v2, r_sum) {
+            if empty_fields == true {
+                None
+            } else {
+                Some((v2 - v1) / r)
+            }
+        } else {
+            None
+        };
+
+        if current.is_some() {
+            let mut pre_voltage = Voltage::default();
+
+            for leg in &mut self.legs.iter_mut().rev() {
+                match (&leg.voltage, current, &leg.resistance) {
+                    (Ok(v), Some(c), Err(_)) => {
+                        leg.resistance = Ok((*v - pre_voltage) / c);
+                        leg.current = Ok(c);
+                        pre_voltage = *v;
+                    }
+                    (Ok(v), Some(c), Ok(_)) => {
+                        leg.current = Ok(c);
+                        pre_voltage = *v;
+                    }
+                    (Err(_), Some(c), Ok(r)) => {
+                        let v = (c * *r) + pre_voltage;
+                        leg.voltage = Ok(v);
+                        leg.current = Ok(c);
+                        pre_voltage = v;
+                    }
+                    (_, None, _) => leg.current = Err(ParserError::EmptyInput),
+                    _ => (),
+                }
+            }
+        }
+    }
+}
+
+pub fn help() -> (String, String) {
+    let title = String::from("Voltage Divider");
+    let text = String::from("
+The program calculates parameters in a resistive voltage divider circuit. It allows you to define the characteristics of each leg of the divider and provides tools for customization.
+
+#### Features and Interface
+1. **Leg Configuration**:  
+   - By default, the circuit starts with two legs.  
+   - You can add additional legs using the **Add Leg** button.  
+   - Each additional leg will have a `-` button on the right for easy deletion.
+
+2. **Automatic Numbering**:  
+   - Legs are numbered automatically, starting from 1, and renumbered dynamically after any additions or deletions.
+
+3. **Input Fields for Each Leg**:  
+   - For each leg, you can specify:  
+      -- **Resistance**: The resistance of the leg (in ohms, Ω).  
+      -- **Voltage**: The voltage at the leg relative to ground (not the voltage drop across the resistor).  
+
+4. **Calculation Requirements**:  
+   - All known fields must be filled in.  
+   - At least one leg must be fully defined, meaning both **resistance** and **voltage** must be provided for that leg.
+
+#### Data Input Format
+##### Value Units
+The input format supports values with units, similar to those used in Ohm's Law calculations. To specify a unit, append the unit prefix directly to the number:  
+- Example: 12m represents 0.012R (milliohms).  
+
+Supported unit prefixes:  
+- **p** (pico, 10⁻¹²),  
+- **n** (nano, 10⁻⁹),  
+- **u** (micro, 10⁻⁶),  
+- **m** (milli, 10⁻³),  
+- **k** (kilo, 10³),  
+- **M** (mega, 10⁶),  
+- **G** (giga, 10⁹).
+
+##### Uncertainty (Error Margins)
+Input values can include error margins using the following formats:  
+- Symmetrical error: 5% (±5% from the value),  
+- Asymmetrical positive error: +5%,  
+- Asymmetrical negative error: -5%,  
+- Symmetrical error: +/-5%.
+
+#### Results
+Once all required parameters are defined, the results will be displayed in a table below the input fields. Calculations account for any defined error margins and unit conversions. The results include:  
+- Voltage distribution across all legs,  
+- Current through each resistor,  
+- Power dissipated by each resistor.");
+
+    (title, text)
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces the initial implementation of the **Electrical Calculation Wizard (ECW)** — a cross-platform desktop application built with Rust and the Iced GUI framework. The application provides two interactive calculators and a help section, all accessible through a sidebar navigation.

## Key Functionality

- **Ohm’s Law Calculator**  
  Users input any two of the four parameters (voltage, current, resistance, power) and the remaining two are automatically calculated. Results are presented in a table showing nominal values, min/max ranges, and tolerance details.

- **Voltage Divider Calculator**  
  Users can define one or more resistive legs (starts with two, add/remove via buttons). For each leg, either resistance or voltage can be specified, and the application calculates the missing values, including current and power for each resistor. Results are shown in structured tables with uncertainty information.

- **Smart Input Parsing**  
  All input fields accept values with SI unit prefixes (p, n, u, m, k, M, G, T) and tolerance expressions. Supported tolerance formats include symmetrical (`5%`), asymmetrical (`+5%`, `-5%`), and combined (`+/-5%`). The parser automatically converts to base units and handles error margins.

- **Uncertainty Propagation**  
  The underlying type system (Voltage, Current, Resistance, Power) implements arithmetic operations that propagate tolerances through calculations, so results always reflect the impact of input uncertainties.

- **Help Module**  
  A built-in markdown-based help section explains both calculators, input format rules, and how to use the application.

- **Polished UI**  
  The app features a clean sidebar layout with themed styling, input validation messages, and scrollable result tables. Window size is fixed at 800×600 with minimum constraints.

This PR marks the first public increment of the project on the `main` branch, laying the foundation for an extensible electrical engineering calculation tool.
<!-- kody-pr-summary:end -->